### PR TITLE
add babel-register to fix error in console

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
+    "babel-register": "6.9.0",
     "colors": "^1.1.2",
     "css-loader": "^0.23.1",
     "enzyme": "^2.3.0",

--- a/src/components/protected/ProtectedPage.js
+++ b/src/components/protected/ProtectedPage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Link} from 'react-router';
-
+import checkAuth from '../requireAuth';
 const ProtectedPage = () => {
   return (
     <div>
@@ -10,4 +10,4 @@ const ProtectedPage = () => {
   );
 };
 
-export default ProtectedPage;
+export default checkAuth(ProtectedPage);

--- a/src/components/requireAuth.js
+++ b/src/components/requireAuth.js
@@ -1,0 +1,35 @@
+/*eslint no-invalid-this: "error"*/
+/*eslint-env es6*/
+import React, { PropTypes, Component } from 'react';
+import {connect} from 'react-redux';
+import toastr from 'toastr';
+
+export default function (ComposedComponent){
+  class Authentication extends Component {
+    componentWillMount(){
+      if(!this.props.authenticated) {
+        this.context.router.push('/login');
+        toastr.error('You need to be logged to access this page');
+      }
+    }
+    componentWillUpdate(nextProps){
+      if(!nextProps.authenticated) {
+        this.context.router.push('/login');
+        toastr.error('You need to be logged to access this page');
+      }
+    }
+    render(){
+              return <ComposedComponent {...this.props}/>;
+      }
+  }
+  Authentication.contextTypes = {
+      router : PropTypes.object
+    };
+  Authentication.propTypes  = {
+    authenticated : PropTypes.bool
+  };
+  const mapStateToProps = (state) => ({
+    authenticated : state.auth.isLogged
+  });
+  return connect(mapStateToProps)(Authentication);
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -7,14 +7,11 @@ import ProtectedPage from './components/protected/ProtectedPage';
 import AboutPage from './components/about/AboutPage';
 import LoginPage from './components/login/LoginPage'; //eslint-disable-line import/no-named-as-default
 import RegistrationPage from './components/registration/RegistrationPage'; //eslint-disable-line import/no-named-as-default
-import {requireAuth, requireAdmin} from './actions/authActions';
+import {requireAdmin} from './actions/authActions';
 
 
 export default function Routes(store) {
 
-  const checkAuth = (nextState, replace) => {
-    store.dispatch(requireAuth(nextState, replace));
-  };
 
   const checkAdmin = (nextState, replace, callback) => {
     store.dispatch(requireAdmin(nextState, replace, callback));
@@ -25,7 +22,7 @@ export default function Routes(store) {
       <IndexRoute component={HomePage}/>
       <Route path="layout" component={Layout}/>
       <Route path="about" component={AboutPage}/>
-      <Route path="protected" component={ProtectedPage} onEnter={checkAuth}/>
+      <Route path="protected" component={ProtectedPage}/>
       <Route path="admin" component={AdminPage} onEnter={checkAdmin}/>
       <Route path="register" component={RegistrationPage}/>
       <Route path="login" component={LoginPage}/>


### PR DESCRIPTION
Hi,
the error in console is from test:watch script.

In the `/tools/testSetup.js` file, there is a requirement for `babel-register` line 16.

```
// Register babel so that it will transpile ES6 to ES5
// before our tests run.
require('babel-register')();
```
